### PR TITLE
Add Simperium provider for notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@wordpress/block-library": "^2.9.1",
     "@wordpress/components": "^8.3.1",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "react-dom": "^16.10.2",
+    "simperium": "^1.0.0"
   }
 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+window.setImmediate = f => setTimeout( f, 0 );
+import React, { useEffect, useState } from "react";
+import Simperium from 'simperium';
 
 /**
  * Gutenberg dependencies:
@@ -21,15 +23,74 @@ import '@wordpress/block-library/build-style/style.css';
 import '@wordpress/block-library/build-style/editor.css';
 import '@wordpress/block-library/build-style/theme.css';
 
+class Ghost {
+	constructor( bucket ) {
+		this.bucket = bucket;
+		this.entries = new Map();
+	}
+
+	getChangeVersion() {
+		return Promise.resolve( this.cv );
+	}
+
+	setChangeVersion( cv ) {
+		this.cv = cv;
+
+		return Promise.resolve( cv );
+	}
+
+	get( id ) {
+		if ( ! this.entries.has( id ) ) {
+			return Promise.resolve( { key: id, data: { blocks: [] } } );
+		}
+
+		return Promise.resolve( this.entries.get( id ) );
+	}
+
+	put( id, version, data ) {
+		this.entries.set( id, { version, data } );
+		return Promise.resolve( true );
+	}
+
+	remove( id ) {
+		this.entries.delete( id );
+		return Promise.resolve();
+	}
+}
 
 const Editor = () => {
+	const [ bucket, setBucket ] = useState( null );
+	const [ loaded, setLoaded ] = useState( false );
 	const [ blocks, updateBlocks ] = useState( [] );
+
+	useEffect( () => {
+		const bucket = Simperium(
+			YOUR_APP_ID_FOR_THIS_DEMO,
+			YOUR_API_TOKEN,
+			{ ghostStoreProvider: bucket => new Ghost( bucket ) }
+		).bucket( 'docs' );
+		setBucket( bucket );
+
+		bucket.on( 'update', ( id, { blocks } ) => {
+			! loaded && setLoaded( true );
+			if ( ! Array.isArray( blocks ) ) {
+				bucket.update( 'blocks', { blocks: [] } );
+			} else {
+				updateBlocks( blocks );
+			}
+		} );
+	}, [] );
+
+	if ( ! loaded ) {
+		return <div>Loading…</div>
+	}
+
 	return (
 		<div id='editor'>
 			<BlockEditorProvider
 				value={ blocks }
-				onInput={ updateBlocks }
-				onChange={ updateBlocks }
+				onInput={ blocks => bucket.update( 'blocks', { blocks } ) }
+				onChange={ blocks => bucket.update( 'blocks', { blocks } ) }
 			>
 				<WritingFlow>
 					<ObserveTyping>

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,6 +587,14 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.6.0"
 
+"@babel/polyfill@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.6.0.tgz#6d89203f8b6cd323e8d946e47774ea35dc0619cc"
+  integrity sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.4.4":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.3.tgz#9e1bf05a2e2d687036d24c40e4639dc46cef2271"
@@ -4234,7 +4242,7 @@ is-touch-device@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-touch-device/-/is-touch-device-1.0.1.tgz#9a2fd59f689e9a9bf6ae9a86924c4ba805a42eab"
   integrity sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -4719,7 +4727,7 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.12.1:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -6379,6 +6387,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simperium@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simperium/-/simperium-1.0.0.tgz#421ce89caeb519506a8d969a8dee9254840dd8c3"
+  integrity sha512-n+UHvdQoUuEu/hFsvssDPjOV6iUQbGtXAdpLQDFtFTKB+fKbKFz/w5kS5z8fGkbkhSJz9GZrK+gBd7efsv82Ew==
+  dependencies:
+    "@babel/polyfill" "^7.6.0"
+    uuid "3.3.3"
+    websocket "1.0.30"
+
 simple-html-tokenizer@^0.5.7:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz#3417382f75954ee34515cc4fd32d9918e693f173"
@@ -6890,6 +6907,13 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -7036,7 +7060,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
+uuid@3.3.3, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -7097,6 +7121,16 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+websocket@1.0.30:
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.30.tgz#91d3bd00c3d43e916f0cf962f8f8c451bb0b2373"
+  integrity sha512-aO6klgaTdSMkhfl5VVJzD5fm+Srhh5jLYbS15+OiI1sN6h/RU/XW6WN9J1uVIpUKNmsTvT3Hs35XAFjn9NMfOw==
+  dependencies:
+    debug "^2.2.0"
+    nan "^2.14.0"
+    typedarray-to-buffer "^3.1.5"
+    yaeti "^0.0.6"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"
@@ -7194,6 +7228,11 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
**This is not meant for merging necessarily. This is meant to build off
of the work done in the base repo and demonstrate a different mechanism
for loading and storing the block data.**

Before running make sure to replace the APP_ID and API_TOKEN with
values you get from your Simperium.com dashboard!

In this patch we're connecting to a new Simperium app and using a
bucket entity to store the contents of the block editor. This is a
list of block nodes.

Loading of the app takes place after conncting to the bucket and may
be funny on the first load. If that's the case you might need to
manually create the new entity...

```
bucket.update( 'blocks', { blocks: [] } );
```

Afterwards you should be able to connect multiple devices from this
branch in different browsers or even on different machines and the
editor contents should stay consistent.

One issue that makes for a buggy experience is that the Simperium
library is replacing the `blocks` data instead of diffing and merging
it. This means that one edit session carries a risk of wiping out the
changes from another session, and if both are offline when they make
their changes then only one's changes will come though. This should
be fixable but I didn't have time in this patch to resolve it.

![simpleberg](https://user-images.githubusercontent.com/5431237/66712130-e3ffcb80-ed4c-11e9-9925-66fa7bde59b9.gif)
